### PR TITLE
fix(timer.h): include algorithm

### DIFF
--- a/include/hermes_shm/util/timer.h
+++ b/include/hermes_shm/util/timer.h
@@ -14,6 +14,7 @@
 #define HERMES_TIMER_H
 
 #include <chrono>
+#include <algorithm>
 #include <vector>
 #include <functional>
 #include "hermes_shm/constants/macros.h"


### PR DESCRIPTION
gcc-14 on ubuntu throws the follwoing error:

```
include/hermes_shm/util/timer_thread.
            h:55:22: error: 'max_element' is not a member of 'std'; did you mean 'tuple_element'?
     time_ns_ = *std::max_element(rank_times.begin(), rank_t
            imes.end());
 ```